### PR TITLE
Revert "v0.1.4: remove unnecessary sources copy step"

### DIFF
--- a/j9-sys/Cargo.toml
+++ b/j9-sys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "j9-sys"
-version = "0.1.4"
+version = "0.1.3"
 authors = ["ynqa <un.pensiero.vano@gmail.com>"]
 edition = "2021"
 description = "Rust bindings for jq"
@@ -14,5 +14,4 @@ readme = "README.md"
 anyhow = "1.0.80"
 autotools = "0.2.6"
 bindgen = "0.69.4"
-filetime = "0.2.25"
 walkdir = "2.5.0"

--- a/j9-sys/build.rs
+++ b/j9-sys/build.rs
@@ -2,13 +2,10 @@ extern crate autotools;
 extern crate bindgen;
 
 use std::{
-    env,
+    env, fs,
     path::{Path, PathBuf},
     process::Command,
-    time::SystemTime,
 };
-
-use filetime::FileTime;
 
 fn check_installed(name: &str) -> anyhow::Result<()> {
     let check = Command::new(name).arg("--version").output();
@@ -40,21 +37,40 @@ fn main() -> anyhow::Result<()> {
 
     let out_dir = env::var("OUT_DIR").map(PathBuf::from)?;
     let src_dir = Path::new(env!("CARGO_MANIFEST_DIR")).join("jq");
+    let build_dir = out_dir.join("jq_build");
 
-    // Modify the timestamp of parser.c file
-    // to circumvent an error on building in Linux that goes something like:
-    //
-    //   clang: error: no such file or directory: 'src/parser.c'
-    //   clang: error: no input files
-    //   make[2]: *** [Makefile:1051: src/parser.lo] Error 1
-    //   make[1]: *** [Makefile:1188: install-recursive] Error 1
-    //   make: *** [Makefile:1709: install] Error 2
-    let now = FileTime::from(SystemTime::now());
+    // Copy the contents of the src_dir to build_dir within OUT_DIR
+    // to avoid modifying the source directory during the build process.
+    // This ensures compliance with Cargo's policy that build scripts
+    // should not modify anything outside of OUT_DIR.
+    if build_dir.exists() {
+        fs::remove_dir_all(&build_dir)?;
+    }
+    fs::create_dir(&build_dir)?;
+    for entry in walkdir::WalkDir::new(&src_dir) {
+        let entry = entry?;
+        let target_path = build_dir.join(entry.path().strip_prefix(&src_dir)?);
+        if entry.file_type().is_dir() {
+            fs::create_dir_all(target_path)?;
+        } else {
+            fs::copy(entry.path(), target_path)?;
+        }
+    }
+
+    // It seems that modifying the timestamp of the lexer.c file by copying
+    // it to the target directory is necessary to circumvent an error that goes something like:
+    //   cc1: fatal error: src/lexer.c: No such file or directory compilation terminated.
+    let lexer_src = src_dir.join("src/lexer.c");
+    let lexer_target = build_dir.join("src/lexer.c");
+    fs::copy(lexer_src, lexer_target)?;
+    // parser.c also
+    //   error: src/parser.c: No such file or directory
     let parser_src = src_dir.join("src/parser.c");
-    filetime::set_file_mtime(&parser_src, now)?;
+    let parser_target = build_dir.join("src/parser.c");
+    fs::copy(parser_src, parser_target)?;
 
     // See https://github.com/jqlang/jq/tree/jq-1.7.1?#instructions
-    autotools::Config::new(&src_dir)
+    autotools::Config::new(&build_dir)
         .reconf("-i")
         .out_dir(&out_dir)
         .with("oniguruma", Some("builtin"))

--- a/j9/Cargo.toml
+++ b/j9/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "j9"
-version = "0.1.4"
+version = "0.1.3"
 authors = ["ynqa <un.pensiero.vano@gmail.com>"]
 edition = "2021"
 description = "Rust interface for jq-based JSON processing"
@@ -12,7 +12,7 @@ name = "j9"
 path = "src/lib.rs"
 
 [dependencies]
-j9-sys = { path = "../j9-sys", version = "0.1.4" }
+j9-sys = { path = "../j9-sys", version = "0.1.3" }
 thiserror = "1.0.57"
 
 [dev-dependencies]

--- a/j9/README.md
+++ b/j9/README.md
@@ -9,7 +9,7 @@ To use j9, add it as a dependency in your Cargo.toml:
 
 ```toml
 [dependencies]
-j9 = "0.1.4"
+j9 = "0.1.3"
 ```
 
 ## Example


### PR DESCRIPTION
Reverts ynqa/j9#5

I forgot that I shouldn’t edit the code when running `cargo publish`.

```
error: Source directory was modified by build.rs during cargo publish. Build scripts should not modify anything outside of OUT_DIR.
```